### PR TITLE
docs: update expired discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![npm version](https://img.shields.io/npm/v/@solidxai/core)](https://www.npmjs.com/package/@solidxai/core)
 [![License: BSL-1.1](https://img.shields.io/badge/License-BSL--1.1-blue.svg)](https://mariadb.com/bsl11/)
 [![Documentation](https://img.shields.io/badge/docs-solidxai.com-blue)](https://docs.solidxai.com/docs)
-[![Discord](https://img.shields.io/badge/discord-online-brightgreen.svg)](https://discord.gg/yh4KZf8c)
+[![Discord](https://img.shields.io/badge/discord-online-brightgreen.svg)](https://discord.gg/ATQW4CEksA)
 
 
 ## Why @solidxai/core?
@@ -189,7 +189,7 @@ The output is not locked into a proprietary runtime. It runs on the same stack y
 |---|---|
 | Website | [solidxai.com](https://solidxai.com) |
 | Documentation | [docs.solidxai.com](https://docs.solidxai.com/docs) |
-| Discord | [discord.gg/yh4KZf8c](https://discord.gg/yh4KZf8c) |
+| Discord | [discord.gg/ATQW4CEksA](https://discord.gg/ATQW4CEksA) |
 | Support | support@solidxai.com |
 
 ---


### PR DESCRIPTION
This PR updates the expired Discord link to the new one across the README.