### PR TITLE
feat(chatter): add secure custom-note edit API with attachment add/re…

### DIFF
--- a/src/controllers/chatter-message.controller.ts
+++ b/src/controllers/chatter-message.controller.ts
@@ -5,6 +5,7 @@ import { ChatterMessageService } from '../services/chatter-message.service';
 import { CreateChatterMessageDto } from '../dtos/create-chatter-message.dto';
 import { UpdateChatterMessageDto } from '../dtos/update-chatter-message.dto';
 import { PostChatterMessageDto } from '../dtos/post-chatter-message.dto';
+import { UpdateChatterNoteMessageDto } from '../dtos/update-chatter-note-message.dto';
 import { SolidRequestContextDecorator } from 'src/decorators/solid-request-context.decorator';
 import { SolidRequestContextDto } from 'src/dtos/solid-request-context.dto';
 import { Public } from 'src/decorators/public.decorator';
@@ -126,5 +127,16 @@ export class ChatterMessageController {
   @Patch(':id/complete')
   async markCompleted(@Param('id') id: string) {
     return this.service.markCompleted(+id);
+  }
+
+  @ApiBearerAuth("jwt")
+  @Patch(':id/note')
+  @UseInterceptors(AnyFilesInterceptor())
+  async updateCustomNoteMessage(
+    @Param('id') id: string,
+    @Body() updateDto: UpdateChatterNoteMessageDto,
+    @UploadedFiles() files: Array<Express.Multer.File>,
+  ) {
+    return this.service.updateCustomNoteMessage(+id, updateDto, files);
   }
 }

--- a/src/dtos/update-chatter-note-message.dto.ts
+++ b/src/dtos/update-chatter-note-message.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class UpdateChatterNoteMessageDto {
+    @IsString()
+    @IsOptional()
+    @ApiProperty()
+    messageBody: string;
+
+    @IsString()
+    @IsOptional()
+    @ApiProperty({ required: false, description: 'Comma-separated media IDs to remove from this note.' })
+    removeAttachmentIds?: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ export * from './decorators/settings-provider.decorator'
 export * from './decorators/extension-user-creation-provider.decorator'
 
 export * from './dtos/post-chatter-message.dto'
+export * from './dtos/update-chatter-note-message.dto'
 export * from './dtos/security-rule-config.dto'
 export * from './dtos/basic-filters.dto'
 export * from './dtos/solid-request-context.dto'

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -42,6 +42,7 @@ export interface ValidationError {
 export interface MediaStorageProvider<T> {
   store(files: Express.Multer.File[], entity: T, mediaFieldMetadata: FieldMetadata): Promise<Media[]>;
   delete(entity: T, mediaFieldMetadata: FieldMetadata): Promise<void>;
+  deleteByMediaRecord(media: Media): Promise<void>;
   retrieve(entity: T, mediaFieldMetadata: FieldMetadata): Promise<Media[]>;
   storeStreams(streamPairs: [Readable, string][], entity: T, mediaFieldMetadata: FieldMetadata): Promise<Media[]>;
   // delete(file: string): Promise<void>;
@@ -450,4 +451,3 @@ export interface AuditQueuePayload {
     updatedColumnNames?: string[];
     userId?: number | null;
 }
-

--- a/src/seeders/seed-data/solid-core-metadata.json
+++ b/src/seeders/seed-data/solid-core-metadata.json
@@ -5970,6 +5970,7 @@
         "ChatterMessageController.postMessage",
         "ChatterMessageController.findMany",
         "ChatterMessageController.markCompleted",
+        "ChatterMessageController.updateCustomNoteMessage",
         "ImportTransactionController.getImportTemplate",
         "ImportTransactionController.getImportInstructions",
         "ImportTransactionController.getImportMappingInfo",

--- a/src/services/chatter-message.service.ts
+++ b/src/services/chatter-message.service.ts
@@ -3,7 +3,6 @@ import { BadRequestException, ForbiddenException, forwardRef, Inject, Injectable
 import { ModuleRef } from "@nestjs/core";
 import { InjectEntityManager } from '@nestjs/typeorm';
 import { Brackets, EntityManager, EntityMetadata, In } from 'typeorm';
-import * as path from 'path';
 
 import { classify } from '@angular-devkit/core/src/utils/strings';
 import { CHATTER_MESSAGE_STATUS, CHATTER_MESSAGE_SUBTYPE, CHATTER_MESSAGE_TYPE } from 'src/constants/chatter-message.constants';
@@ -24,9 +23,6 @@ import { ChatterMessage } from '../entities/chatter-message.entity';
 import { getMediaStorageProvider } from './mediaStorageProviders';
 import { RequestContextService } from './request-context.service';
 import { Logger } from '@nestjs/common';
-import { DiskFileService, S3FileService } from './file';
-import { DEFAULT_MEDIA_FILE_STORAGE_DIR } from "src/services/settings/default-settings-provider.service";
-import type { SolidCoreSetting } from "src/services/settings/default-settings-provider.service";
 
 @Injectable()
 export class ChatterMessageService extends CRUDService<ChatterMessage> {
@@ -50,8 +46,6 @@ export class ChatterMessageService extends CRUDService<ChatterMessage> {
         private readonly modelMetadataRepo: ModelMetadataRepository,
         readonly requestContextService: RequestContextService,
         private readonly modelMetadataHelperService: ModelMetadataHelperService,
-        private readonly diskFileService: DiskFileService,
-        private readonly s3FileService: S3FileService,
     ) {
         super(entityManager, repo, 'chatterMessage', 'solid-core', moduleRef);
     }
@@ -89,15 +83,6 @@ export class ChatterMessageService extends CRUDService<ChatterMessage> {
             .split(',')
             .map(v => Number(v.trim()))
             .filter(v => Number.isInteger(v) && v > 0);
-    }
-
-    private getFullFilePathForDisk(relativeUri: string): string {
-        const base = this.settingService.getConfigValue<SolidCoreSetting>("fileStorageDir")
-            || DEFAULT_MEDIA_FILE_STORAGE_DIR;
-        if (path.isAbsolute(relativeUri) || relativeUri.startsWith(`${base}/`)) {
-            return relativeUri;
-        }
-        return `${base}/${relativeUri}`;
     }
 
     async markCompleted(id: number) {
@@ -183,15 +168,8 @@ export class ChatterMessageService extends CRUDService<ChatterMessage> {
 
                 for (const media of mediaToRemove) {
                     const storageType = media.mediaStorageProviderMetadata?.type as MediaStorageProviderType;
-                    if (storageType === MediaStorageProviderType.AwsS3) {
-                        const bucketName = media.mediaStorageProviderMetadata?.bucketName;
-                        const region = media.mediaStorageProviderMetadata?.region;
-                        if (bucketName && media.relativeUri) {
-                            await this.s3FileService.delete(`${bucketName}:${media.relativeUri}`, { region });
-                        }
-                    } else if (media.relativeUri) {
-                        await this.diskFileService.delete(this.getFullFilePathForDisk(media.relativeUri));
-                    }
+                    const storageProvider = await getMediaStorageProvider(this.moduleRef, storageType);
+                    await storageProvider.deleteByMediaRecord(media);
                 }
 
                 if (mediaToRemove.length > 0) {

--- a/src/services/chatter-message.service.ts
+++ b/src/services/chatter-message.service.ts
@@ -1,18 +1,21 @@
 import { LocalDateTimeTransformer, serializeDate } from 'src/transformers/typeorm/local-date-time-transformer';
-import { BadRequestException, forwardRef, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, forwardRef, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { ModuleRef } from "@nestjs/core";
 import { InjectEntityManager } from '@nestjs/typeorm';
-import { Brackets, EntityManager, EntityMetadata } from 'typeorm';
+import { Brackets, EntityManager, EntityMetadata, In } from 'typeorm';
+import * as path from 'path';
 
 import { classify } from '@angular-devkit/core/src/utils/strings';
 import { CHATTER_MESSAGE_STATUS, CHATTER_MESSAGE_SUBTYPE, CHATTER_MESSAGE_TYPE } from 'src/constants/chatter-message.constants';
 import { ERROR_MESSAGES } from 'src/constants/error-messages';
 import { PostChatterMessageDto } from 'src/dtos/post-chatter-message.dto';
+import { UpdateChatterNoteMessageDto } from 'src/dtos/update-chatter-note-message.dto';
 import { ModelMetadataHelperService } from 'src/helpers/model-metadata-helper.service';
 import { lowerFirst } from 'src/helpers/string.helper';
 import { ChatterMessageDetailsRepository } from 'src/repository/chatter-message-details.repository';
 import { ChatterMessageRepository } from 'src/repository/chatter-message.repository';
 import { FieldMetadataRepository } from 'src/repository/field-metadata.repository';
+import { MediaRepository } from 'src/repository/media.repository';
 import { ModelMetadataRepository } from 'src/repository/model-metadata.repository';
 import { CRUDService } from 'src/services/crud.service';
 import { MediaStorageProviderType } from '../dtos/create-media-storage-provider-metadata.dto';
@@ -21,6 +24,9 @@ import { ChatterMessage } from '../entities/chatter-message.entity';
 import { getMediaStorageProvider } from './mediaStorageProviders';
 import { RequestContextService } from './request-context.service';
 import { Logger } from '@nestjs/common';
+import { DiskFileService, S3FileService } from './file';
+import { DEFAULT_MEDIA_FILE_STORAGE_DIR } from "src/services/settings/default-settings-provider.service";
+import type { SolidCoreSetting } from "src/services/settings/default-settings-provider.service";
 
 @Injectable()
 export class ChatterMessageService extends CRUDService<ChatterMessage> {
@@ -33,6 +39,7 @@ export class ChatterMessageService extends CRUDService<ChatterMessage> {
         readonly repo: ChatterMessageRepository,
         // @InjectRepository(ChatterMessageDetailsRepository, 'default')
         readonly chatterMessageDetailsRepo: ChatterMessageDetailsRepository,
+        readonly mediaRepository: MediaRepository,
         // @InjectRepository(FieldMetadata, 'default')
         // readonly fieldMetadataRepo: Repository<FieldMetadata>,
         readonly fieldMetadataRepo: FieldMetadataRepository,
@@ -43,6 +50,8 @@ export class ChatterMessageService extends CRUDService<ChatterMessage> {
         private readonly modelMetadataRepo: ModelMetadataRepository,
         readonly requestContextService: RequestContextService,
         private readonly modelMetadataHelperService: ModelMetadataHelperService,
+        private readonly diskFileService: DiskFileService,
+        private readonly s3FileService: S3FileService,
     ) {
         super(entityManager, repo, 'chatterMessage', 'solid-core', moduleRef);
     }
@@ -67,6 +76,30 @@ export class ChatterMessageService extends CRUDService<ChatterMessage> {
         chatterMessage.updatedBy = resolvedUserId;
     }
 
+    private isEditableCustomNoteMessage(message: ChatterMessage): boolean {
+        if (message.messageType !== CHATTER_MESSAGE_TYPE.CUSTOM) {
+            return false;
+        }
+        return [CHATTER_MESSAGE_SUBTYPE.CUSTOM, CHATTER_MESSAGE_SUBTYPE.NOTE].includes(message.messageSubType as any);
+    }
+
+    private parseAttachmentIds(value?: string): number[] {
+        if (!value || typeof value !== 'string') return [];
+        return value
+            .split(',')
+            .map(v => Number(v.trim()))
+            .filter(v => Number.isInteger(v) && v > 0);
+    }
+
+    private getFullFilePathForDisk(relativeUri: string): string {
+        const base = this.settingService.getConfigValue<SolidCoreSetting>("fileStorageDir")
+            || DEFAULT_MEDIA_FILE_STORAGE_DIR;
+        if (path.isAbsolute(relativeUri) || relativeUri.startsWith(`${base}/`)) {
+            return relativeUri;
+        }
+        return `${base}/${relativeUri}`;
+    }
+
     async markCompleted(id: number) {
         const activeUser = this.requestContextService.getActiveUser();
         if (!activeUser) {
@@ -80,6 +113,105 @@ export class ChatterMessageService extends CRUDService<ChatterMessage> {
 
         message.status = CHATTER_MESSAGE_STATUS.COMPLETED;
         return this.repo.save(message);
+    }
+
+    async updateCustomNoteMessage(id: number, updateDto: UpdateChatterNoteMessageDto, files: Express.Multer.File[] = []) {
+        const activeUser = this.requestContextService.getActiveUser();
+        if (!activeUser) {
+            throw new ForbiddenException(ERROR_MESSAGES.FORBIDDEN);
+        }
+
+        const message = await this.repo.findOne({ where: { id }, relations: { user: true } });
+        if (!message) {
+            throw new NotFoundException(`Entity [solid-core.chatterMessage] with id ${id} not found`);
+        }
+
+        if (!this.isEditableCustomNoteMessage(message)) {
+            throw new BadRequestException('Only custom note messages can be edited.');
+        }
+
+        if (!message.user?.id || message.user.id !== activeUser.sub) {
+            throw new ForbiddenException('You can only edit your own custom note messages.');
+        }
+
+        const removeAttachmentIds = this.parseAttachmentIds(updateDto?.removeAttachmentIds);
+        const hasMessageBody = typeof updateDto?.messageBody === 'string';
+        const trimmedMessageBody = (updateDto?.messageBody ?? '').trim();
+        const hasNewFiles = Array.isArray(files) && files.length > 0;
+
+        if (!hasMessageBody && removeAttachmentIds.length === 0 && !hasNewFiles) {
+            throw new BadRequestException('No note changes submitted.');
+        }
+
+        if (hasMessageBody && trimmedMessageBody.length === 0) {
+            throw new BadRequestException('Message body cannot be empty.');
+        }
+
+        if (hasMessageBody) {
+            message.messageBody = trimmedMessageBody;
+        }
+        message.updatedBy = activeUser.sub;
+        // Ensure updatedAt changes even for attachment-only edits.
+        message.updatedAt = new Date();
+        const savedMessage = await this.repo.save(message);
+
+        if (removeAttachmentIds.length > 0 || hasNewFiles) {
+            const model = await this.modelMetadataService.findOneBySingularName('chatterMessage', {
+                fields: {
+                    model: true,
+                    mediaStorageProvider: true,
+                },
+                module: true,
+            });
+
+            const mediaFields = model.fields.filter(field => field.type === 'mediaSingle' || field.type === 'mediaMultiple');
+            const attachmentFieldIds = mediaFields.map(field => field.id);
+
+            if (removeAttachmentIds.length > 0 && attachmentFieldIds.length > 0) {
+                const mediaToRemove = await this.mediaRepository.find({
+                    where: {
+                        id: In(removeAttachmentIds),
+                        entityId: savedMessage.id,
+                        modelMetadata: { id: model.id },
+                        fieldMetadata: { id: In(attachmentFieldIds) },
+                    },
+                    relations: {
+                        mediaStorageProviderMetadata: true,
+                        fieldMetadata: true,
+                    },
+                });
+
+                for (const media of mediaToRemove) {
+                    const storageType = media.mediaStorageProviderMetadata?.type as MediaStorageProviderType;
+                    if (storageType === MediaStorageProviderType.AwsS3) {
+                        const bucketName = media.mediaStorageProviderMetadata?.bucketName;
+                        const region = media.mediaStorageProviderMetadata?.region;
+                        if (bucketName && media.relativeUri) {
+                            await this.s3FileService.delete(`${bucketName}:${media.relativeUri}`, { region });
+                        }
+                    } else if (media.relativeUri) {
+                        await this.diskFileService.delete(this.getFullFilePathForDisk(media.relativeUri));
+                    }
+                }
+
+                if (mediaToRemove.length > 0) {
+                    await this.mediaRepository.remove(mediaToRemove);
+                }
+            }
+
+            for (const mediaField of mediaFields) {
+                const storageProviderMetadata = mediaField.mediaStorageProvider;
+                const storageProviderType = storageProviderMetadata.type as MediaStorageProviderType;
+                const storageProvider = await getMediaStorageProvider(this.moduleRef, storageProviderType);
+
+                const media = files.filter(multerFile => multerFile.fieldname === mediaField.name);
+                if (media.length > 0) {
+                    await storageProvider.store(media, savedMessage, mediaField);
+                }
+            }
+        }
+
+        return savedMessage;
     }
 
     async postMessage(postDto: PostChatterMessageDto, files: Express.Multer.File[] = []) {

--- a/src/services/mediaStorageProviders/file-s3-storage-provider.ts
+++ b/src/services/mediaStorageProviders/file-s3-storage-provider.ts
@@ -120,6 +120,18 @@ export class FileS3StorageProvider<T> implements MediaStorageProvider<T> {
         }
     }
 
+    async deleteByMediaRecord(media: Media): Promise<void> {
+        const storageProvider = media?.mediaStorageProviderMetadata;
+        if (!storageProvider) {
+            throw new Error(`mediaStorageProviderMetadata is not populated for media id ${media?.id ?? 'unknown'}`);
+        }
+        if (!storageProvider?.bucketName || !media?.relativeUri) {
+            return;
+        }
+        const region = this.getEffectiveRegion(storageProvider.region);
+        await this.s3FileService.delete(`${storageProvider.bucketName}:${media.relativeUri}`, { region });
+    }
+
     /**
      * Get the effective region to use for S3 operations.
      * Uses the provider-specific region if configured, otherwise falls back to env variable.

--- a/src/services/mediaStorageProviders/file-storage-provider.ts
+++ b/src/services/mediaStorageProviders/file-storage-provider.ts
@@ -110,6 +110,13 @@ export class FileStorageProvider<T> implements MediaStorageProvider<T> {
         // });
     }
 
+    async deleteByMediaRecord(media: Media): Promise<void> {
+        if (!media?.relativeUri) {
+            return;
+        }
+        await this.fileService.delete(this.getFullFilePath(media.relativeUri));
+    }
+
     private getFullFilePath(fileName: string): string {
         const base = this.settingService.getConfigValue<SolidCoreSetting>("fileStorageDir")
             || DEFAULT_MEDIA_FILE_STORAGE_DIR;


### PR DESCRIPTION
feat(chatter): add secure custom-note edit API with attachment add/remove support

add PATCH /chatter-message/:id/note multipart endpoint for note edits
allow edits only for custom/note messages authored by current user
support selective attachment deletion via removeAttachmentIds
support uploading new attachments during edit in same request
ensure updatedAt is bumped on successful note edit flows
export new note-update DTO in module index

https://erp2.logicloop.io/web#id=11842&cids=1&menu_id=167&action=256&active_id=23&model=project.task&view_type=form