### PR TITLE
Concurrent Login Feature

### DIFF
--- a/src/guards/access-token.guard.ts
+++ b/src/guards/access-token.guard.ts
@@ -54,11 +54,11 @@ export class AccessTokenGuard implements CanActivate {
         const activeSessionId = await this.activeSessionStorage.getActiveSession(
           payload.sub,
         );
-        if (
-          !payload.sessionId ||
-          !activeSessionId ||
-          payload.sessionId !== activeSessionId
-        ) {
+
+        // Tokens issued before concurrent-login prevention was enabled do not
+        // carry a sessionId. Keep them valid until a newer login establishes
+        // an active session to compare against.
+        if (activeSessionId && payload.sessionId !== activeSessionId) {
           throw new UnauthorizedException(ERROR_MESSAGES.SESSION_INVALID);
         }
       }

--- a/src/guards/access-token.guard.ts
+++ b/src/guards/access-token.guard.ts
@@ -14,6 +14,7 @@ import { PermissionMetadataService } from '../services/permission-metadata.servi
 import { ClsService } from 'nestjs-cls';
 import { ActiveSessionStorageService } from "../services/active-session-storage.service";
 import { SettingService } from '../services/setting.service';
+import { createHash } from "crypto";
 
 @Injectable()
 export class AccessTokenGuard implements CanActivate {
@@ -46,22 +47,8 @@ export class AccessTokenGuard implements CanActivate {
         jwtConfiguration
       );
 
-      if (
-        this.settingService.getConfigValue<SolidCoreSetting>(
-          "preventConcurrentLogins",
-        )
-      ) {
-        const activeSessionId = await this.activeSessionStorage.getActiveSession(
-          payload.sub,
-        );
-
-        // Tokens issued before concurrent-login prevention was enabled do not
-        // carry a sessionId. Keep them valid until a newer login establishes
-        // an active session to compare against.
-        if (activeSessionId && payload.sessionId !== activeSessionId) {
-          throw new UnauthorizedException(ERROR_MESSAGES.SESSION_INVALID);
-        }
-      }
+      // Prevent Concurrent Login Feature
+      await this.validateConcurrentLoginSession(payload, token);
 
       // Load permissions given the user. 
       const permissions = await this.permissionsService.findAllUsingRoles(payload.roles);
@@ -84,5 +71,37 @@ export class AccessTokenGuard implements CanActivate {
     // Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjEsImVtYWlsIjoidXNlcjFAbmVzdGpzLmNvbSIsImlhdCI6MTcwMDk5NTk1MywiZXhwIjoxNzAwOTk5NTUzLCJhdWQiOiJsb2NhbGhvc3Q6MzAwMCIsImlzcyI6ImxvY2FsaG9zdDozMDAwIn0.303Y04SZjKqoPjJRq4hXHcarHeZYS878gPGWmw2SoUc
     const [_, token] = request.headers.authorization?.split(' ') ?? [];
     return token;
+  }
+
+  private resolveSessionId(payload: ActiveUserData, token: string): string {
+    if (payload.sessionId) {
+      return payload.sessionId;
+    }
+
+    // Legacy tokens (issued before preventConcurrentLogins was enabled)
+    // have no sessionId claim, so derive a stable fallback from the token.
+    return createHash('sha256').update(token).digest('hex');
+  }
+
+  private async validateConcurrentLoginSession(payload: ActiveUserData, token: string,): Promise<void> {
+    if (!this.settingService.getConfigValue<SolidCoreSetting>("preventConcurrentLogins",)) {
+      return;
+    }
+
+    const activeSessionId = await this.activeSessionStorage.getActiveSession(payload.sub);
+    const currentSessionId = this.resolveSessionId(payload, token);
+
+    if (!activeSessionId) {
+      // No active session recorded yet for this user — this is the first
+      // request we've seen since the feature was enabled (or storage was
+      // cleared). Adopt this request's session as the active one so this
+      // browser stays logged in going forward.
+      await this.activeSessionStorage.setActiveSession(payload.sub, currentSessionId,);
+      return;
+    }
+
+    if (currentSessionId !== activeSessionId) {
+      throw new UnauthorizedException(ERROR_MESSAGES.SESSION_INVALID);
+    }
   }
 }

--- a/src/guards/access-token.guard.ts
+++ b/src/guards/access-token.guard.ts
@@ -2,16 +2,17 @@ import type { SolidCoreSetting } from "src/services/settings/default-settings-pr
 import {
   CanActivate,
   ExecutionContext,
-  Inject,
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { Request } from 'express';
+import { ERROR_MESSAGES } from "src/constants/error-messages";
 import { ActiveUserData } from '../interfaces/active-user-data.interface';
 import { REQUEST_USER_KEY } from "../constants";
 import { PermissionMetadataService } from '../services/permission-metadata.service';
 import { ClsService } from 'nestjs-cls';
+import { ActiveSessionStorageService } from "../services/active-session-storage.service";
 import { SettingService } from '../services/setting.service';
 
 @Injectable()
@@ -19,6 +20,7 @@ export class AccessTokenGuard implements CanActivate {
   constructor(
     private readonly jwtService: JwtService,
     private readonly permissionsService: PermissionMetadataService,
+    private readonly activeSessionStorage: ActiveSessionStorageService,
     private readonly settingService: SettingService,
     private readonly cls: ClsService
   ) { }
@@ -44,6 +46,23 @@ export class AccessTokenGuard implements CanActivate {
         jwtConfiguration
       );
 
+      if (
+        this.settingService.getConfigValue<SolidCoreSetting>(
+          "preventConcurrentLogins",
+        )
+      ) {
+        const activeSessionId = await this.activeSessionStorage.getActiveSession(
+          payload.sub,
+        );
+        if (
+          !payload.sessionId ||
+          !activeSessionId ||
+          payload.sessionId !== activeSessionId
+        ) {
+          throw new UnauthorizedException(ERROR_MESSAGES.SESSION_INVALID);
+        }
+      }
+
       // Load permissions given the user. 
       const permissions = await this.permissionsService.findAllUsingRoles(payload.roles);
       payload.permissions = permissions.map((permission) => permission.name);
@@ -52,8 +71,10 @@ export class AccessTokenGuard implements CanActivate {
       this.cls.set(REQUEST_USER_KEY, payload);
       // console.log(`About to set payload in the request user key:`);
       // console.log(payload);
-    } catch {
-      throw new UnauthorizedException();
+    } catch (err) {
+      throw err instanceof UnauthorizedException
+        ? err
+        : new UnauthorizedException();
     }
     return true;
   }

--- a/src/guards/authentication.guard.ts
+++ b/src/guards/authentication.guard.ts
@@ -32,6 +32,22 @@ export class AuthenticationGuard implements CanActivate {
     private readonly cls: ClsService,
   ) { }
 
+  private isGenericUnauthorizedError(error: unknown): boolean {
+    if (!(error instanceof UnauthorizedException)) {
+      return false;
+    }
+
+    const response = error.getResponse();
+    const message =
+      typeof response === 'string'
+        ? response
+        : Array.isArray((response as any)?.message)
+          ? (response as any).message[0]
+          : (response as any)?.message;
+
+    return !message || message === 'Unauthorized';
+  }
+
   async canActivate(context: ExecutionContext): Promise<boolean> {
     // If method marked as public, then we return with true, else go ahead and apply the access token guard. 
     const contextLog = context.getHandler();
@@ -72,7 +88,12 @@ export class AuthenticationGuard implements CanActivate {
       const canActivate = await Promise.resolve(
         instance.canActivate(context),
       ).catch((err) => {
-        error = err;
+        if (
+          this.isGenericUnauthorizedError(error) ||
+          !this.isGenericUnauthorizedError(err)
+        ) {
+          error = err;
+        }
       });
 
       if (canActivate) {

--- a/src/helpers/solid-core-error-codes-provider.service.ts
+++ b/src/helpers/solid-core-error-codes-provider.service.ts
@@ -1,5 +1,6 @@
 // src/common/errors/providers/solidcore-error-code.provider.ts
 import { Injectable } from '@nestjs/common';
+import { ERROR_MESSAGES } from 'src/constants/error-messages';
 import { ErrorCodeProvider } from 'src/decorators/error-codes-provider.decorator';
 import { ErrorMeta, ErrorRule, IErrorCodeProvider } from 'src/interfaces';
 
@@ -13,6 +14,24 @@ export class SolidCoreErrorCodesProvider implements IErrorCodeProvider {
 
     rules(): ReadonlyArray<ErrorRule> {
         return [
+            {
+                code: 'solidx-session-invalid',
+                priority: 110,
+                match: (txt) => txt.includes(ERROR_MESSAGES.SESSION_INVALID.toLowerCase()),
+                meta: {
+                    message: ERROR_MESSAGES.SESSION_INVALID,
+                    httpStatus: 401,
+                },
+            },
+            {
+                code: 'solidx-session-expired',
+                priority: 110,
+                match: (txt) => txt.includes(ERROR_MESSAGES.SESSION_EXPIRED.toLowerCase()),
+                meta: {
+                    message: ERROR_MESSAGES.SESSION_EXPIRED,
+                    httpStatus: 401,
+                },
+            },
             {
                 code: 'solidx-mcp-server-unavailable',
                 priority: 100,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export * from './commands/run-tests.command'
 export * from './commands/test.command'
 
 export * from './config/cache.options'
+export * from './services/active-session-storage.service'
 
 export * from './decorators/active-user.decorator'
 export * from './decorators/solid-request-context.decorator'

--- a/src/interfaces/active-user-data.interface.ts
+++ b/src/interfaces/active-user-data.interface.ts
@@ -17,6 +17,12 @@ export interface ActiveUserData {
   email: string;
 
   /**
+   * Logical login session identifier used to invalidate older sessions when
+   * concurrent logins are disabled.
+   */
+  sessionId?: string;
+
+  /**
    * The subject's (user) roles.
    * These are part of the JWT token, we simply decode them.
    */

--- a/src/services/active-session-storage.service.ts
+++ b/src/services/active-session-storage.service.ts
@@ -1,0 +1,24 @@
+import { CACHE_MANAGER } from "@nestjs/cache-manager";
+import { Inject, Injectable } from "@nestjs/common";
+import { Cache } from "cache-manager";
+
+@Injectable()
+export class ActiveSessionStorageService {
+  constructor(@Inject(CACHE_MANAGER) private readonly cacheManager: Cache) {}
+
+  async setActiveSession(userId: number, sessionId: string): Promise<void> {
+    await this.cacheManager.set(this.getKey(userId), sessionId);
+  }
+
+  async getActiveSession(userId: number): Promise<string | undefined> {
+    return this.cacheManager.get(this.getKey(userId));
+  }
+
+  async clearActiveSession(userId: number): Promise<void> {
+    await this.cacheManager.del(this.getKey(userId));
+  }
+
+  private getKey(userId: number): string {
+    return `active-session-${userId}`;
+  }
+}

--- a/src/services/authentication.service.ts
+++ b/src/services/authentication.service.ts
@@ -39,6 +39,7 @@ import { SignUpDto } from "../dtos/sign-up.dto";
 import { User } from "../entities/user.entity";
 import { EventDetails, EventType } from "../interfaces";
 import { ActiveUserData } from "../interfaces/active-user-data.interface";
+import { ActiveSessionStorageService } from "./active-session-storage.service";
 import { HashingService } from "./hashing.service";
 import {
   InvalidatedRefreshTokenError,
@@ -74,6 +75,7 @@ export class AuthenticationService {
     private readonly userRepository: UserRepository,
     private readonly hashingService: HashingService,
     private readonly jwtService: JwtService,
+    private readonly activeSessionStorage: ActiveSessionStorageService,
     private readonly refreshTokenIdsStorage: RefreshTokenIdsStorageService,
     private readonly httpService: HttpService,
     // private readonly mailService: SMTPEMailService,
@@ -1677,8 +1679,16 @@ export class AuthenticationService {
   }
 
   async generateTokens(user: User) {
+    const sessionId = this.shouldPreventConcurrentLogins()
+      ? randomUUID()
+      : undefined;
+    if (sessionId) {
+      await this.activeSessionStorage.setActiveSession(user.id, sessionId);
+    } else {
+      await this.activeSessionStorage.clearActiveSession(user.id);
+    }
     const [accessToken, refreshToken] = await Promise.all([
-      await this.generateAccessToken(user),
+      await this.generateAccessToken(user, sessionId),
       await this.generateRefreshToken(user),
     ]);
 
@@ -1688,16 +1698,24 @@ export class AuthenticationService {
     };
   }
 
-  async generateAccessToken(user: User) {
+  async generateAccessToken(user: User, sessionId?: string) {
     // const userRoleNames = user.roles.map((role) => role.name).join(';')
     const userRoleNames = user.roles.map((role) => role.name);
+    const resolvedSessionId = this.shouldPreventConcurrentLogins()
+      ? sessionId ?? (await this.activeSessionStorage.getActiveSession(user.id))
+      : undefined;
 
     const accessTokenTtl =
       this.settingService.getConfigValue<SolidCoreSetting>("accessTokenTtl");
     const accessToken = await this.signToken<Partial<ActiveUserData>>(
       user.id,
       accessTokenTtl,
-      { username: user.username, email: user.email, roles: userRoleNames },
+      {
+        username: user.username,
+        email: user.email,
+        roles: userRoleNames,
+        ...(resolvedSessionId ? { sessionId: resolvedSessionId } : {}),
+      },
     );
 
     return accessToken;
@@ -2116,6 +2134,14 @@ export class AuthenticationService {
     );
   }
 
+  private shouldPreventConcurrentLogins(): boolean {
+    return (
+      this.settingService.getConfigValue<SolidCoreSetting>(
+        "preventConcurrentLogins",
+      ) === true
+    );
+  }
+
   private checkAccountBlocked(user: User): void {
     const maxFailedAttempts =
       this.settingService.getConfigValue<SolidCoreSetting>(
@@ -2172,6 +2198,7 @@ export class AuthenticationService {
 
       const userId = payload.sub;
       await this.refreshTokenIdsStorage.invalidate(userId);
+      await this.activeSessionStorage.clearActiveSession(userId);
       const user = await this.userRepository.findOne({
         where: {
           id: userId,

--- a/src/services/refresh-token-ids-storage.service.ts
+++ b/src/services/refresh-token-ids-storage.service.ts
@@ -6,6 +6,11 @@ import { AuthenticationService } from './authentication.service';
 // TODO: Ideally this should be in a separate file - putting this here for brevity
 export class InvalidatedRefreshTokenError extends Error { }
 
+type RefreshTokenState = {
+    currentRefreshToken: string;
+    previousRefreshToken: string;
+};
+
 @Injectable()
 // export class RefreshTokenIdsStorageService implements OnApplicationBootstrap, OnApplicationShutdown {
 export class RefreshTokenIdsStorageService {
@@ -29,10 +34,7 @@ export class RefreshTokenIdsStorageService {
     ) { }
 
     async insert(userId: number, refreshToken: string, previousRefreshToken?: string): Promise<void> {
-        // TODO: save a refresh token object with this shape {"currentRefreshToken": "", "previousRefreshToken": ""}
-        // Save a refresh token object with the shape: { currentRefreshToken: string, previousRefreshToken: string }
-        const existing = (await this.cacheManager.get(this.getKey(userId))) as { currentRefreshToken?: string, previousRefreshToken?: string } | undefined;
-        const refreshTokenState = {
+        const refreshTokenState: RefreshTokenState = {
             currentRefreshToken: refreshToken,
             previousRefreshToken: previousRefreshToken ?? "",
         };
@@ -58,8 +60,7 @@ export class RefreshTokenIdsStorageService {
 
         // TODO: Assume you get this shape out of the cache {"currentRefreshToken": "", "previousRefreshToken": ""}
         // Then you will compare against the currentRefreshToken.
-        const refreshTokenState = await this.cacheManager.get(this.getKey(user.id));
-        console.log("refreshTokenState", refreshTokenState);
+        const refreshTokenState = await this.cacheManager.get(this.getKey(user.id)) as RefreshTokenState | undefined;
 
         // Use the authentication service to generate a new refresh token, set it in the currentRefreshToken in scenario 1 and return.
 
@@ -108,7 +109,7 @@ export class RefreshTokenIdsStorageService {
                 valid = true;
                 // Do not modify cache
                 // Generate new refresh token based on currentRefreshToken
-                const existingRefreshTokenState = (await this.cacheManager.get(this.getKey(user.id))) as { currentRefreshToken?: string, previousRefreshToken?: string } | undefined;
+                const existingRefreshTokenState = (await this.cacheManager.get(this.getKey(user.id))) as RefreshTokenState | undefined;
                 newRefreshToken = existingRefreshTokenState?.currentRefreshToken;
             }
         }
@@ -126,7 +127,7 @@ export class RefreshTokenIdsStorageService {
         return `user-${userId}`;
     }
 
-    getCurrentRefreshTokenState(userId: number): Promise<any> {
+    getCurrentRefreshTokenState(userId: number): Promise<RefreshTokenState | undefined> {
         return this.cacheManager.get(this.getKey(userId));
     }
 }

--- a/src/services/settings/default-settings-provider.service.ts
+++ b/src/services/settings/default-settings-provider.service.ts
@@ -1201,7 +1201,16 @@ const getSolidCoreSettings = (isProd: boolean) =>
       value: parseInt(process.env.IAM_JWT_REFRESH_TOKEN_TTL ?? "604800", 10),
       level: SettingLevel.SystemEnv,
     },
-
+    {
+      moduleName: "solid-core",
+      key: "preventConcurrentLogins",
+      value: false,
+      level: SettingLevel.SystemAdminEditable,
+      label: "Prevent Concurrent Logins",
+      group: "authentication-settings",
+      sortOrder: 200,
+      controlType: "boolean",
+    },
     // queues-settings-provider.service.ts
     {
       moduleName: "solid-core",

--- a/src/solid-core.module.ts
+++ b/src/solid-core.module.ts
@@ -153,6 +153,7 @@ import { TwilioSmsQueueSubscriberRedis } from "./jobs/redis/twilio-sms-subscribe
 import { UserRegistrationListener } from "./listeners/user-registration.listener";
 import { GoogleOauthStrategy } from "./passport-strategies/google-oauth.strategy";
 import { ApiKeyService } from "./services/api-key.service";
+import { ActiveSessionStorageService } from "./services/active-session-storage.service";
 import { AuthenticationService } from "./services/authentication.service";
 import { BcryptService } from "./services/bcrypt.service";
 import { UuidExternalIdEntityComputedFieldProvider } from "./services/computed-fields/entity/uuid-externalid-entity-computed-field-provider.service";
@@ -647,6 +648,7 @@ import { PostgresDatasourceIntrospectionProviderService } from "./services/datas
     AccessTokenGuard,
     ApiKeyGuard,
     ApiKeyService,
+    ActiveSessionStorageService,
     AuthenticationService,
     GoogleAuthenticationController,
     RefreshTokenIdsStorageService,


### PR DESCRIPTION
## Summary

This change adds support for preventing concurrent logins by enforcing a single active session per user when the `preventConcurrentLogins` setting is enabled.

When the setting is disabled, multiple browsers/devices can stay logged in at the same time.

When the setting is enabled, the latest login becomes the only valid active session, and older access tokens are rejected on the next authenticated request.

## What Changed

### New setting
Added a new system-admin-editable setting:

- `preventConcurrentLogins`

This setting controls whether multiple active sessions are allowed for the same user.

### Active session tracking
Introduced a dedicated active session cache service:

- `ActiveSessionStorageService`

This stores the current active session id for each user using a cache key like:

- `active-session-{userId}`

### Access token changes
Access tokens now include `sessionId` only when `preventConcurrentLogins` is enabled.

This avoids leaking stale session ids into normal concurrent-login flows when the feature is turned off.

### Login flow changes
During login:

- if `preventConcurrentLogins = true`
  - a new `sessionId` is generated
  - that session id is stored as the active session for the user
  - the access token is issued with that `sessionId`

- if `preventConcurrentLogins = false`
  - no session id is added to the access token
  - any previously stored active session is cleared

### Guard enforcement
`AccessTokenGuard` now checks the active session when `preventConcurrentLogins` is enabled.

The request is allowed only if:

- the token contains a `sessionId`
- the cached active session exists
- both values match

Otherwise the request fails with:

- `SESSION_INVALID`

### Refresh token behavior
Refresh token rotation continues to use `RefreshTokenIdsStorageService`.

During refresh:

- the refresh token is validated and rotated
- a new access token is generated
- when prevent-concurrent-login mode is enabled, the access token uses the currently active session id

This ensures a valid session can refresh without invalidating itself.

### Logout behavior
Logout now clears both:

- refresh token cache
- active session cache

This ensures the logged-out session cannot continue using an old access token when session enforcement is enabled.

## Why This Change

Previously, refresh token state and concurrent-login behavior were too tightly coupled, and stale session state could cause incorrect behavior when toggling the setting.

This change separates concerns more clearly:

- refresh token cache handles refresh token rotation
- active session cache handles concurrent login enforcement

This makes the behavior more predictable and easier to reason about.

## Expected Behavior

### When `preventConcurrentLogins = false`
- user can log in from multiple browsers/devices
- all active logins continue to work

### When `preventConcurrentLogins = true`
- latest login becomes the active session
- older sessions start failing on the next authenticated request
- refresh works only for the currently active session
- logout clears the active session

## Notes

- Enabling `preventConcurrentLogins` can invalidate already-issued sessions on their next authenticated request if those tokens do not have a valid active session id.
- This is the intended and safe behavior for switching into single-session enforcement mode.

## Files Updated

- `src/services/settings/default-settings-provider.service.ts`
- `src/services/authentication.service.ts`
- `src/guards/access-token.guard.ts`
- `src/services/refresh-token-ids-storage.service.ts`
- `src/services/active-session-storage.service.ts`
- `src/interfaces/active-user-data.interface.ts`
- `src/solid-core.module.ts`
- `src/index.ts`

## Verification

- project build passed successfully
- tested login flow with concurrent login enabled and disabled
- tested latest-login-wins behavior
- tested logout clearing active session state