### PR TITLE
Deliverable A now stands as: cache TTL (with the store swap that make…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "bcrypt": "^5.1.1",
         "bson": "^6.10.1",
         "cache-manager": "^5.5.2",
-        "cache-manager-redis-store": "^3.0.1",
+        "cache-manager-redis-yet": "^5.1.5",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "cron-parser": "^5.5.0",
@@ -279,6 +279,24 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/@angular-devkit/schematics-cli/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@angular-devkit/schematics-cli/node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -290,6 +308,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@angular-devkit/schematics-cli/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@angular-devkit/schematics-cli/node_modules/rxjs": {
@@ -347,6 +381,24 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/@angular-devkit/schematics/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@angular-devkit/schematics/node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -358,6 +410,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@angular-devkit/schematics/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@angular-devkit/schematics/node_modules/rxjs": {
@@ -7442,16 +7510,24 @@
         "node": ">= 18"
       }
     },
-    "node_modules/cache-manager-redis-store": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/cache-manager-redis-store/-/cache-manager-redis-store-3.0.1.tgz",
-      "integrity": "sha512-o560kw+dFqusC9lQJhcm6L2F2fMKobJ5af+FoR2PdnMVdpQ3f3Bz6qzvObTGyvoazQJxjQNWgMQeChP4vRTuXQ==",
+    "node_modules/cache-manager-redis-yet": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/cache-manager-redis-yet/-/cache-manager-redis-yet-5.1.5.tgz",
+      "integrity": "sha512-NYDxrWBoLXxxVPw4JuBriJW0f45+BVOAsgLiozRo4GoJQyoKPbueQWYStWqmO73/AeHJeWrV7Hzvk6vhCGHlqA==",
+      "deprecated": "With cache-manager v6 we now are using Keyv",
       "license": "MIT",
       "dependencies": {
-        "redis": "^4.3.1"
+        "@redis/bloom": "^1.2.0",
+        "@redis/client": "^1.6.0",
+        "@redis/graph": "^1.1.1",
+        "@redis/json": "^1.0.7",
+        "@redis/search": "^1.2.0",
+        "@redis/time-series": "^1.1.0",
+        "cache-manager": "^5.7.6",
+        "redis": "^4.7.0"
       },
       "engines": {
-        "node": ">= 16.18.0"
+        "node": ">= 18"
       }
     },
     "node_modules/cache-manager/node_modules/lru-cache": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "bcrypt": "^5.1.1",
     "bson": "^6.10.1",
     "cache-manager": "^5.5.2",
-    "cache-manager-redis-store": "^3.0.1",
+    "cache-manager-redis-yet": "^5.1.5",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "cron-parser": "^5.5.0",

--- a/src/config/cache.options.ts
+++ b/src/config/cache.options.ts
@@ -1,6 +1,14 @@
 import { CacheModuleAsyncOptions } from '@nestjs/cache-manager';
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { redisStore } from 'cache-manager-redis-store';
+// cache-manager-redis-yet, not cache-manager-redis-store. The latter stops at
+// 3.0.1 and implements the cache-manager v4 store contract: it expects an
+// options object and reads `options.ttl` in seconds. cache-manager v5 calls
+// `store.set(key, value, ttl)` with a bare number of milliseconds, so that
+// store found no `.ttl`, fell back to an unset default, and issued a plain
+// `SET` - silently discarding every TTL passed anywhere in the app and leaving
+// Redis keys that never expire. redis-yet implements the v5 contract and
+// writes with `PX`, so millisecond TTLs land correctly.
+import { redisStore } from 'cache-manager-redis-yet';
 import { isRedisConfigured } from 'src/helpers/environment.helper';
 
 export const CacheManagerOptions: CacheModuleAsyncOptions = {

--- a/src/helpers/solid-microservice-adapter.service.ts
+++ b/src/helpers/solid-microservice-adapter.service.ts
@@ -79,7 +79,12 @@ export class SolidMicroserviceAdapter {
     const responseData = response.data as SolidxIamAuthResponse;
     const ttlSeconds = this.getJwtTtlSeconds(responseData?.data?.accessToken);
     if (ttlSeconds && ttlSeconds > 0) {
-      await this.cacheManager.set(cacheKey, responseData, ttlSeconds);
+      // cache-manager v5 expects milliseconds. This previously passed seconds,
+      // which the old Redis store discarded outright - so the entry simply
+      // never expired. Now that TTLs are honoured, passing seconds unconverted
+      // would expire the cached token ~1000x too early and re-authenticate
+      // against IAM on nearly every call.
+      await this.cacheManager.set(cacheKey, responseData, ttlSeconds * 1000);
     }
 
     return responseData;

--- a/src/services/authentication.service.ts
+++ b/src/services/authentication.service.ts
@@ -2293,22 +2293,18 @@ export class AuthenticationService {
   // }
   async logout(refreshToken: string) {
     try {
-      // const activeUser = this.requestContextService.getActiveUser();
-      // const userId = activeUser?.sub;
-      // const user = await this.userRepository.findOne({
-      //     where: {
-      //         id: userId,
-      //     }
-      // })
-      // // Invalidate refresh token if you store them
-      // await this.refreshTokenIdsStorage.invalidate(userId); // ← Your existing logic
-      // if (!refreshToken) {
-      //     throw new UnauthorizedException('Refresh token is required');
-      // }
-      const payload = this.jwtService.decode(refreshToken) as any;
+      const payload = await this.verifyRefreshTokenForLogout(refreshToken);
 
-      if (!payload || !payload.sub) {
-        throw new UnauthorizedException(ERROR_MESSAGES.INVALID_REFRESH_TOKEN);
+      // Nothing verifiable to act on: forged, malformed, or signed with another
+      // secret. Acting on an unauthenticated `sub` is exactly the hole this
+      // closes - the route is @Public(), so a decoded-but-unverified token let
+      // anyone log out an arbitrary user. Report success either way: logout
+      // must be safe to call blindly from a client error path, and a 401/200
+      // split here would leak whether a token string is genuine (RFC 7009 §2.2
+      // takes the same position for revocation endpoints).
+      if (!payload?.sub) {
+        this.logger.warn("logout called with an unverifiable refresh token");
+        return { message: SUCCESS_MESSAGES.LOGOUT_SUCCESS };
       }
 
       const userId = payload.sub;
@@ -2320,14 +2316,44 @@ export class AuthenticationService {
         },
       });
       // Log logout event
-      await this.userActivityHistoryService.logEvent("logout", user);
+      if (user) {
+        await this.userActivityHistoryService.logEvent("logout", user);
+      }
 
       return { message: SUCCESS_MESSAGES.LOGOUT_SUCCESS };
     } catch (err: any) {
+      // JWT problems no longer reach here - verifyRefreshTokenForLogout
+      // swallows them - so this is left for genuine infrastructure failures
+      // (cache or database unavailable), where a 500 is the correct answer.
       throw err instanceof UnauthorizedException ||
         err instanceof InternalServerErrorException
         ? err
         : new InternalServerErrorException(ERROR_MESSAGES.LOGOUT_FAILED);
+    }
+  }
+
+  private async verifyRefreshTokenForLogout(
+    refreshToken: string,
+  ): Promise<{ sub: number } | null> {
+    try {
+      const payload = await this.jwtService.verifyAsync(refreshToken, {
+        secret: this.settingService.getConfigValue<SolidCoreSetting>("secret"),
+        audience:
+          this.settingService.getConfigValue<SolidCoreSetting>("audience"),
+        issuer: this.settingService.getConfigValue<SolidCoreSetting>("issuer"),
+        // Signature, audience and issuer are still enforced; only `exp` is
+        // tolerated. An expired session must still be able to log out - the
+        // previous jwtService.decode() allowed that, and a plain verifyAsync
+        // would throw TokenExpiredError, which the catch above would turn into
+        // a 500 on an ordinary sign-out.
+        ignoreExpiration: true,
+      });
+
+      // Access and refresh tokens share secret, audience and issuer, so only
+      // this claim distinguishes them. Reject an access token presented here.
+      return payload?.refreshTokenId ? payload : null;
+    } catch {
+      return null; // bad signature or malformed
     }
   }
 
@@ -2365,7 +2391,11 @@ export class AuthenticationService {
         id: user.id,
         roles: user.roles.map((role) => role.name),
       },
-      refreshToken: refreshTokenState.currentRefreshToken,
+      // Null-guarded because the cache entry now carries a TTL: once it
+      // expires - or after a logout followed by a call with a still-valid
+      // access token - there is no state to read. Matches the existing
+      // handling in generateSsoCode.
+      refreshToken: refreshTokenState?.currentRefreshToken ?? null,
       // ...tokens
     };
     return response;

--- a/src/services/refresh-token-ids-storage.service.ts
+++ b/src/services/refresh-token-ids-storage.service.ts
@@ -1,54 +1,55 @@
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Inject, Injectable, forwardRef } from '@nestjs/common';
 import { Cache } from 'cache-manager';
+import type { SolidCoreSetting } from 'src/services/settings/default-settings-provider.service';
 import { AuthenticationService } from './authentication.service';
+import { SettingService } from './setting.service';
 
 // TODO: Ideally this should be in a separate file - putting this here for brevity
 export class InvalidatedRefreshTokenError extends Error { }
 
+// How long a rotated-out refresh token stays acceptable. This window is the
+// point of keeping a previous token at all: concurrent requests from one user
+// must not break each other. core-ui's single-flight guard is module-level and
+// therefore per tab, so two tabs crossing the refresh threshold together will
+// both present the same token - the second one is served from here.
+const PREVIOUS_TOKEN_GRACE_MS = 60 * 1000;
+
+// The cache entry must outlive the JWT it holds. If it expired first, refresh
+// would fail with ACCESS_DENIED (InvalidatedRefreshTokenError) rather than the
+// SESSION_EXPIRED that the token's own `exp` produces - the same event
+// reported two different ways.
+const STATE_TTL_BUFFER_SECONDS = 60;
+
 type RefreshTokenState = {
     currentRefreshToken: string;
     previousRefreshToken: string;
+    // Absolute epoch-ms deadline after which previousRefreshToken is refused.
+    // Stored rather than scheduled: an in-process timer is lost when the pod
+    // restarts, which used to leave the rotated-out token valid until the next
+    // rotation instead of for one minute. Optional because entries written
+    // before this field existed will not carry it.
+    previousValidUntil?: number;
 };
 
 @Injectable()
-// export class RefreshTokenIdsStorageService implements OnApplicationBootstrap, OnApplicationShutdown {
 export class RefreshTokenIdsStorageService {
-    // private redisClient: Redis;
-    // onApplicationBootstrap() {
-    //     // TODO: Ideally, we should move this to the dedicated "RedisModule" instead of initiating the connection here.
-    //     this.redisClient = new Redis({
-    //         // TODO: According to best practices, we should use the environment variables here instead.
-    //         host: 'localhost',
-    //         port: 6379,
-    //     });
-    // }
-    // onApplicationShutdown(signal?: string) {
-    //     return this.redisClient.quit();
-    // }
-
     constructor(
         @Inject(CACHE_MANAGER) private cacheManager: Cache,
         @Inject(forwardRef(() => AuthenticationService))
-        private readonly authenticationService: AuthenticationService
+        private readonly authenticationService: AuthenticationService,
+        private readonly settingService: SettingService,
     ) { }
 
     async insert(userId: number, refreshToken: string, previousRefreshToken?: string): Promise<void> {
         const refreshTokenState: RefreshTokenState = {
             currentRefreshToken: refreshToken,
             previousRefreshToken: previousRefreshToken ?? "",
+            ...(previousRefreshToken
+                ? { previousValidUntil: Date.now() + PREVIOUS_TOKEN_GRACE_MS }
+                : {}),
         };
-        await this.cacheManager.set(this.getKey(userId), refreshTokenState);
-    }
-
-    async validate(userId: number, refreshToken: string): Promise<boolean> {
-        // TODO: Assume you get this shape out of the cache {"currentRefreshToken": "", "previousRefreshToken": ""}
-        // Then you will compare against the currentRefreshToken.
-        const storedId = await this.cacheManager.get(this.getKey(userId));
-        if (storedId !== refreshToken) {
-            throw new InvalidatedRefreshTokenError();
-        }
-        return storedId === refreshToken;
+        await this.cacheManager.set(this.getKey(userId), refreshTokenState, this.getStateTtlMs());
     }
 
     async invalidate(userId: number): Promise<void> {
@@ -56,78 +57,78 @@ export class RefreshTokenIdsStorageService {
     }
 
     async validateAndRotate(user: any, refreshToken: string): Promise<string> {
-        let valid = false;
-
-        // TODO: Assume you get this shape out of the cache {"currentRefreshToken": "", "previousRefreshToken": ""}
-        // Then you will compare against the currentRefreshToken.
         const refreshTokenState = await this.cacheManager.get(this.getKey(user.id)) as RefreshTokenState | undefined;
 
-        // Use the authentication service to generate a new refresh token, set it in the currentRefreshToken in scenario 1 and return.
-
-        // if UI.refresh_token is matching with Cache.currentRefreshToken
-        //   then invalidate (updated cache state, no need to delete anything), then generate new token and return.
-        //   also set a setTimeout to run after X minutes, this will simply update the RefreshTokenCacheState to this object {"currentRefreshToken": "R2","justInvalidatedRefreshToken": ""}
-        // valid=true
-
-        //   - if UI.refresh_token is matching Cache.justInvalidatedRefreshToken        
-        //       then use the Cache.currentRefreshToken, generate new access token and return.
-        //       We do not modify the cache state at all.
-        // valid=true
-
-        let newRefreshToken: string | undefined;
-        if (
-            refreshTokenState &&
-            typeof refreshTokenState === 'object' &&
-            'currentRefreshToken' in refreshTokenState &&
-            'previousRefreshToken' in refreshTokenState
-        ) {
-            if (refreshTokenState.currentRefreshToken === refreshToken) {
-                // Scenario 1: Token matches currentRefreshToken
-                valid = true;
-                // Rotate tokens: move current to previous, set new current (simulate generation)
-                newRefreshToken = await this.authenticationService.generateRefreshToken(user, refreshTokenState.currentRefreshToken); // Replace with real token generation logic
-
-
-                //   updated cache state
-                // await this.cacheManager.set(this.getKey(user.id), {
-                //     currentRefreshToken: newRefreshToken,
-                //     previousRefreshToken: refreshTokenState.currentRefreshToken,
-                // });
-
-                // Optionally, set a timeout to clear previousRefreshToken after X minutes
-                setTimeout(async () => {
-                    const state = (await this.cacheManager.get(this.getKey(user.id))) as any;
-                    if (state && state.currentRefreshToken === newRefreshToken) {
-                        await this.cacheManager.set(this.getKey(user.id), {
-                            currentRefreshToken: newRefreshToken,
-                            previousRefreshToken: "",
-                        });
-                    }
-                }, 1 * 60 * 1000); // 5 minutes
-            } else if (refreshTokenState.previousRefreshToken === refreshToken) {
-                // Scenario 2: Token matches previousRefreshToken
-                valid = true;
-                // Do not modify cache
-                // Generate new refresh token based on currentRefreshToken
-                const existingRefreshTokenState = (await this.cacheManager.get(this.getKey(user.id))) as RefreshTokenState | undefined;
-                newRefreshToken = existingRefreshTokenState?.currentRefreshToken;
-            }
-        }
-
-
-        if (!valid) {
+        if (!this.isRefreshTokenState(refreshTokenState)) {
             throw new InvalidatedRefreshTokenError();
         }
 
-        // TODO: return the refresh token either currentRefreshToken
-        return newRefreshToken; // Fallback to the provided tokenId if no new token was generated
+        // Scenario 1: the live token. Rotate it. generateRefreshToken calls
+        // insert(), which writes the new state and stamps the grace deadline
+        // onto the token being rotated out.
+        if (refreshTokenState.currentRefreshToken === refreshToken) {
+            return await this.authenticationService.generateRefreshToken(user, refreshToken);
+        }
+
+        // Scenario 2: the token just rotated out. This is the concurrent-request
+        // case the previous slot exists for - a second in-flight request that
+        // was issued the old token before the first one rotated it. Hand back
+        // the live token so it succeeds, provided the grace window is still open.
+        if (refreshTokenState.previousRefreshToken && refreshTokenState.previousRefreshToken === refreshToken) {
+            if (!this.isWithinGraceWindow(refreshTokenState)) {
+                throw new InvalidatedRefreshTokenError();
+            }
+            return refreshTokenState.currentRefreshToken;
+        }
+
+        throw new InvalidatedRefreshTokenError();
+    }
+
+    getCurrentRefreshTokenState(userId: number): Promise<RefreshTokenState | undefined> {
+        return this.cacheManager.get(this.getKey(userId));
     }
 
     private getKey(userId: number): string {
         return `user-${userId}`;
     }
 
-    getCurrentRefreshTokenState(userId: number): Promise<RefreshTokenState | undefined> {
-        return this.cacheManager.get(this.getKey(userId));
+    // cache-manager v5 expects milliseconds; refreshTokenTtl is configured in
+    // seconds. Without an explicit TTL these entries never expire - neither
+    // cache path supplies a default - and the keyspace grows without bound.
+    private getStateTtlMs(): number {
+        const refreshTokenTtlSeconds = Number(
+            this.settingService.getConfigValue<SolidCoreSetting>("refreshTokenTtl"),
+        );
+        return (refreshTokenTtlSeconds + STATE_TTL_BUFFER_SECONDS) * 1000;
+    }
+
+    private isRefreshTokenState(state: unknown): state is RefreshTokenState {
+        return (
+            !!state &&
+            typeof state === 'object' &&
+            'currentRefreshToken' in state &&
+            'previousRefreshToken' in state
+        );
+    }
+
+    private isWithinGraceWindow(state: RefreshTokenState): boolean {
+        // TRANSITIONAL - safe to delete one refreshTokenTtl after this ships.
+        //
+        // Entries written before previousValidUntil existed carry no deadline
+        // to test. They are accepted so that the deploy rejects nobody: a tab
+        // that legitimately rotated moments earlier keeps working. The cost is
+        // that for such an entry the previous token stays acceptable until its
+        // own JWT `exp` rather than for 60s - which is exactly how the old code
+        // already behaved whenever its in-process timer was lost to a restart,
+        // so this is an unfixed pre-existing case, not a new one.
+        //
+        // It self-heals: the user's next rotation writes a new-format state
+        // with a deadline. Once every pre-deploy entry has rotated or expired
+        // (one refreshTokenTtl), this branch is unreachable - drop it, and the
+        // undefined case becomes a rejection.
+        if (state.previousValidUntil === undefined) {
+            return true;
+        }
+        return Date.now() < state.previousValidUntil;
     }
 }


### PR DESCRIPTION
…s it actually work), the me() null guard it necessitates, the logout verify/idempotency fix, previousValidUntil replacing the timer, and the dead validate() removed.