### PR TITLE
feat: make dangerous-extension denylist configurable, add svg support

### DIFF
--- a/src/constants/media-file-types.ts
+++ b/src/constants/media-file-types.ts
@@ -8,8 +8,71 @@ export type MediaFileTypeDefinition = {
     extension: string;
 };
 
-// Single source of truth for every supported media extension, its canonical MIME type,
-// and the coarse media category used across validation and UI metadata.
+/**
+ * Extensions that must never be accepted as media uploads, regardless of declared mimetype or
+ * admin-configured mediaTypes allowlist. Checked before any other resolution so a spoofed
+ * Content-Type (e.g. application/octet-stream on an .html file) can't bypass this.
+ *
+ * The default list below. A deployment can replace it wholesale via AB_DANGEROUS_EXTENSIONS
+ * (comma-separated) - e.g. to accept svg uploads, which some clients legitimately need. This
+ * replaces rather than narrows the list: whatever is set there becomes the entire denylist, so
+ * anything left out of it becomes an accepted upload type. See default-settings-provider.service.ts
+ * for the read-only "dangerousExtensions" setting that surfaces the effective list to admins.
+ */
+const DEFAULT_DANGEROUS_EXTENSIONS = [
+    'html', 'htm', 'xhtml', 'svg', 'xml',
+    'js', 'mjs', 'php', 'phtml', 'jsp', 'asp', 'aspx',
+    'exe', 'sh', 'bat', 'cmd', 'ps1', 'jar', 'dll',
+    'msi', 'msix', 'msp', 'com', 'scr', 'vbs', 'vbe', 'wsf', 'wsh', 'hta', 'cpl', 'pif', 'reg',
+];
+
+const parseExtensionList = (raw: string): string[] =>
+    raw.split(',').map(ext => ext.toLowerCase().trim().replace(/^\./, '')).filter(Boolean);
+
+const configuredDangerousExtensions = parseExtensionList(process.env.AB_DANGEROUS_EXTENSIONS ?? '');
+
+export const DANGEROUS_EXTENSIONS = new Set(
+    configuredDangerousExtensions.length > 0
+        ? configuredDangerousExtensions
+        : DEFAULT_DANGEROUS_EXTENSIONS
+);
+
+/**
+ * The mimetype gate must track the extension gate: a .svg upload arrives as image/svg+xml, so
+ * removing svg from DANGEROUS_EXTENSIONS while image/svg+xml stayed on a separate literal would
+ * still reject the upload at isDangerousMediaFile's second check - with a message pointing at
+ * nothing the operator changed. Deriving from a single mapping keeps the two in sync.
+ *
+ * Only browser-rendered types appear here, which is why the resulting set is short (a handful of
+ * entries against dozens of dangerous extensions): everything else is dangerous once downloaded
+ * and run, and the mimetype sent for those is typically application/octet-stream, which must stay
+ * allowed. When adding a browser-renderable extension to the denylist above, add it here too.
+ */
+const DANGEROUS_MIME_TYPES_BY_EXTENSION: Record<string, string[]> = {
+    html: ['text/html'],
+    htm: ['text/html'],
+    xhtml: ['application/xhtml+xml'],
+    svg: ['image/svg+xml'],
+};
+
+/**
+ * Mimetypes that are never safe to accept, regardless of extension. These render as active
+ * content in a browser (svg can carry <script>), so they are rejected even when the filename
+ * looks harmless. Kept in sync with DANGEROUS_EXTENSIONS via DANGEROUS_MIME_TYPES_BY_EXTENSION
+ * above, rather than maintained separately.
+ */
+export const DANGEROUS_MIME_TYPES = new Set(
+    Object.entries(DANGEROUS_MIME_TYPES_BY_EXTENSION)
+        .filter(([extension]) => DANGEROUS_EXTENSIONS.has(extension))
+        .flatMap(([, mimeTypes]) => mimeTypes)
+);
+
+// The set of media extensions the system currently recognises - its canonical MIME type, and the
+// coarse media category used across validation and UI metadata. Membership here means
+// "resolvable", not "safe": svg is included only when DANGEROUS_EXTENSIONS has been configured to
+// allow it (see below), since accepting it as an upload also makes it eligible for the inline-safe
+// serving path (INLINE_SAFE_EXTENSIONS further down) - safe there only because of the
+// Content-Security-Policy applied when serving it (solid-core.module.ts, media.controller.ts).
 export const MEDIA_FILE_TYPES: MediaFileTypeDefinition[] = [
     { mediaType: 'image', mimeType: 'image/png', extension: 'png' },
     { mediaType: 'image', mimeType: 'image/jpeg', extension: 'jpg' },
@@ -21,6 +84,12 @@ export const MEDIA_FILE_TYPES: MediaFileTypeDefinition[] = [
     { mediaType: 'image', mimeType: 'image/tiff', extension: 'tiff' },
     { mediaType: 'image', mimeType: 'image/heic', extension: 'heic' },
     { mediaType: 'image', mimeType: 'image/heif', extension: 'heif' },
+    // Only a media type when explicitly unblocked via AB_DANGEROUS_EXTENSIONS - see the file
+    // header comment. Hardcoded to svg specifically: unblocking e.g. html must not make html a
+    // media type, since it isn't a format the product supports as an upload.
+    ...(DANGEROUS_EXTENSIONS.has('svg')
+        ? []
+        : [{ mediaType: 'image', mimeType: 'image/svg+xml', extension: 'svg' } as MediaFileTypeDefinition]),
 
     { mediaType: 'audio', mimeType: 'audio/mpeg', extension: 'mp3' },
     { mediaType: 'audio', mimeType: 'audio/mp3', extension: 'mp3' },
@@ -96,28 +165,6 @@ export const MIME_TO_MEDIA_TYPE: Record<string, MediaCategory> = MEDIA_FILE_TYPE
     }
     return acc;
 }, {} as Record<string, MediaCategory>);
-
-/**
- * Extensions that must never be accepted as media uploads, regardless of declared mimetype or
- * admin-configured mediaTypes allowlist. Checked before any other resolution so a spoofed
- * Content-Type (e.g. application/octet-stream on an .html file) can't bypass this.
- */
-export const DANGEROUS_EXTENSIONS = new Set([
-    'html', 'htm', 'xhtml', 'svg', 'xml',
-    'js', 'mjs', 'php', 'phtml', 'jsp', 'asp', 'aspx',
-    'exe', 'sh', 'bat', 'cmd', 'ps1', 'jar', 'dll',
-    'msi', 'msix', 'msp', 'com', 'scr', 'vbs', 'vbe', 'wsf', 'wsh', 'hta', 'cpl', 'pif', 'reg',
-]);
-
-
-/**
- * Mimetypes that are never safe to accept, regardless of extension. These render as active
- * content in a browser (svg can carry <script>), so they are rejected even when the filename
- * looks harmless. Kept alongside DANGEROUS_EXTENSIONS so upload paths check both.
- */
-export const DANGEROUS_MIME_TYPES = new Set([
-    'image/svg+xml', 'text/html', 'application/xhtml+xml',
-]);
 
 /**
  * Percent-decodes a filename, repeating a bounded number of times so a double-encoded payload
@@ -264,6 +311,11 @@ export const EXT_TO_MEDIA_TYPE: Record<string, MediaCategory> = {
 /**
  * Extensions safe to serve inline with their natural Content-Type; everything else served from
  * media-files-storage is forced to application/octet-stream + Content-Disposition: attachment.
+ *
+ * svg is included here only when it's an accepted media type (see MEDIA_FILE_TYPES above) - and
+ * even then it's inline-safe only because both serve paths (ServeStaticModule in
+ * solid-core.module.ts, and the signed-URL download in media.controller.ts) attach a
+ * Content-Security-Policy to svg responses that neutralizes any embedded script.
  */
 export const INLINE_SAFE_EXTENSIONS = new Set<string>([
     ...IMAGE_EXTENSIONS,

--- a/src/controllers/media.controller.ts
+++ b/src/controllers/media.controller.ts
@@ -9,7 +9,7 @@ import { SolidRequestContextDto } from 'src/dtos/solid-request-context.dto';
 import { UpdateMediaDto } from 'src/dtos/update-media.dto';
 import { MediaService } from 'src/services/media.service';
 import { Response } from 'express';
-import { getLowercaseFileExtension, INLINE_SAFE_EXTENSIONS } from 'src/constants/media-file-types';
+import { EXTENSION_TO_MIME_TYPE, getLowercaseFileExtension, INLINE_SAFE_EXTENSIONS } from 'src/constants/media-file-types';
 import { setFileDownloadHeaders } from 'src/helpers/file-download.helper';
 
 import { ShowSoftDeleted } from '../enums/show-soft-deleted.enum';
@@ -100,15 +100,30 @@ export class MediaController {
     // types is ever safe to render inline. Anything else is forced to download rather than be
     // displayed/executed, regardless of the mimetype the record was stored with - nosniff
     // alone would not help here, since it faithfully honours a declared text/html.
-    const isInlineSafe = INLINE_SAFE_EXTENSIONS.has(getLowercaseFileExtension(fileName) ?? '');
+    const ext = getLowercaseFileExtension(fileName) ?? '';
+    const isInlineSafe = INLINE_SAFE_EXTENSIONS.has(ext);
     const requestedInline = disposition !== 'attachment';
+
+    // The served mimetype is derived from the extension rather than trusting the stored
+    // mimeType (which is the client-declared Content-Type at upload time, and so is spoofable):
+    // a file named logo.png could otherwise have been uploaded with Content-Type: image/svg+xml
+    // and stored that way, which would bypass an extension-only check below.
+    const effectiveMimeType = isInlineSafe ? (EXTENSION_TO_MIME_TYPE[ext] ?? mimeType) : 'application/octet-stream';
 
     setFileDownloadHeaders(res, {
       fileName,
-      mimeType: isInlineSafe ? mimeType : 'application/octet-stream',
+      mimeType: effectiveMimeType,
       disposition: requestedInline && isInlineSafe ? 'inline' : 'attachment',
       crossOriginResourcePolicy: true,
     });
+
+    // See the matching comment in solid-core.module.ts's setHeaders: <img>/CSS never execute
+    // svg script, but a direct navigation to this URL would, so pin it to a locked-down
+    // document. Keyed on the extension (which now drives effectiveMimeType above too), not on
+    // the stored mimeType, so the spoofed-Content-Type case above is covered as well.
+    if (ext === 'svg') {
+      res.setHeader("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; img-src data:; sandbox");
+    }
 
     stream.pipe(res);
   }

--- a/src/services/settings/default-settings-provider.service.ts
+++ b/src/services/settings/default-settings-provider.service.ts
@@ -7,6 +7,7 @@ import {
   SettingLevel,
 } from "src/interfaces";
 import { getDefaultThemeKey, getThemesByMode } from "src/theme/theme-registry";
+import { DANGEROUS_EXTENSIONS } from "src/constants/media-file-types";
 
 export const DEFAULT_MEDIA_UPLOAD_DIR = "media-uploads";
 export const DEFAULT_MEDIA_FILE_STORAGE_DIR = "media-files-storage";
@@ -545,6 +546,17 @@ const getSolidCoreSettings = (isProd: boolean) =>
       sortOrder: 45,
       controlType: "numeric",
       helpText: "Global upload size limit enforced by Multer under every per-field mediaMaxSizeKb restriction. Read-only here: it's applied once at process start, so changing AB_MEDIA_MAX_FILE_SIZE_MB requires an app restart to take effect - editing this in the admin UI would not do that.",
+    },
+    {
+      moduleName: "solid-core",
+      key: "dangerousExtensions",
+      value: [...DANGEROUS_EXTENSIONS].join(','),
+      level: SettingLevel.SystemAdminReadonly,
+      label: "Blocked Upload Extensions",
+      group: "storage-settings",
+      sortOrder: 46,
+      controlType: "shortText",
+      helpText: "File extensions rejected on every upload path, regardless of field configuration. Read-only here: it's applied once at process start. To change it, copy this value into AB_DANGEROUS_EXTENSIONS, edit it, and restart - note that variable REPLACES this list rather than adding to it, so any extension you leave out becomes an accepted upload type.",
     },
 
     // aws-s3-settings-provider.service.ts

--- a/src/solid-core.module.ts
+++ b/src/solid-core.module.ts
@@ -541,16 +541,26 @@ import { SwitchNode } from './services/workflow/nodes/switch.node';
           res.setHeader("X-Content-Type-Options", "nosniff");
 
           // Only a small allowlist of media types is ever safe to render inline. Everything
-          // else (including svg, html, and any other uploaded file) is forced to download
+          // else (including html and any other uploaded file) is forced to download
           // rather than be displayed/executed by the browser, regardless of what mimetype or
           // extension it was uploaded with.
           // basename first: getLowercaseFileExtension takes a file name, not a path, so a
           // directory containing a dot must not be mistaken for the extension. An
           // extensionless file yields undefined, which is not inline-safe - so it correctly
           // falls through to the forced-download branch.
-          if (!INLINE_SAFE_EXTENSIONS.has(getLowercaseFileExtension(basename(path)) ?? '')) {
+          const ext = getLowercaseFileExtension(basename(path)) ?? '';
+          if (!INLINE_SAFE_EXTENSIONS.has(ext)) {
             res.setHeader("Content-Type", "application/octet-stream");
             res.setHeader("Content-Disposition", "attachment");
+          }
+
+          // svg is only ever inline-safe (see INLINE_SAFE_EXTENSIONS) once it can also render
+          // as an active document (<script>, event handlers). <img>/CSS never execute it, but
+          // a direct navigation to this URL would - so pin it to a locked-down document: no
+          // script, no network, and `sandbox` gives it an opaque origin so even a parser bypass
+          // can't reach app cookies or storage.
+          if (ext === 'svg') {
+            res.setHeader("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; img-src data:; sandbox");
           }
         },
       },


### PR DESCRIPTION
Adds AB_DANGEROUS_EXTENSIONS to override the default upload denylist wholesale, so a deployment that needs SVG uploads (or anything else) can opt in without weakening the default for everyone else. With the var unset, every constant is byte-for-byte identical to today.

- media-file-types.ts: DEFAULT_DANGEROUS_EXTENSIONS (today's list, unchanged) is used unless AB_DANGEROUS_EXTENSIONS is set, in which case it replaces the list wholesale. DANGEROUS_MIME_TYPES is now derived from a small extension->mimetype mapping so the two gates can't drift. MEDIA_FILE_TYPES gains an svg/image entry only when svg is not in the effective denylist - every downstream consumer (category resolution, INLINE_SAFE_EXTENSIONS, both UI metadata feeds) inherits this automatically with no added branching.

- solid-core.module.ts + media.controller.ts: attach a locked-down Content-Security-Policy (default-src 'none'; sandbox; ...) to any svg response on both serve paths, so it renders in <img>/CSS but can't execute as a document. media.controller.ts additionally derives the served mimetype from the file extension rather than trusting the stored client-declared mimetype, closing a spoof where a non-svg-extension file stored with a svg mimetype would otherwise dodge the extension-keyed CSP check.

- default-settings-provider.service.ts: read-only "dangerousExtensions" setting surfacing the effective (post-override) list to admins, so changing AB_DANGEROUS_EXTENSIONS is a copy-paste-and-edit operation rather than requiring log/source access.

Known gap, tracked as a follow-up rather than fixed here: S3-backed storage writes the client-declared mimetype into the object's ContentType at PUT and plays it back verbatim on presigned GETs, with no equivalent extension-derivation step - DANGEROUS_MIME_TYPES remains the only gate against a Content-Type-spoofed upload there today.