### PR TITLE
refactor: optimize many-to-many relation loading for audit tracking

### DIFF
--- a/src/services/crud.service.ts
+++ b/src/services/crud.service.ts
@@ -300,15 +300,23 @@ private async prepareManyToManyAuditSnapshot(entity: T,id: number,modelSingularN
             field.relationType !== 'one-to-many'
         );
         if (auditRelationFields.length > 0) {
-            const relations: any = {};
-            auditRelationFields.forEach(field => relations[field.name] = true);
+            // Fetch each audit-tracked relation independently rather than joining all of
+            // them into a single query: for an entity with several many-to-many
+            // relations, one combined query multiplies row counts across every joined
+            // relation at once and can blow past the statement timeout as data grows.
             const auditBeforeEntity = await this.repo.findOne({
                 where: {
                     id: id,
                 } as unknown as FindOptionsWhere<T>,
-                relations: relations as any,
             });
             if (auditBeforeEntity) {
+                for (const field of auditRelationFields) {
+                    (auditBeforeEntity as any)[field.name] = await this.repo.manager
+                        .createQueryBuilder()
+                        .relation(this.repo.target, field.name)
+                        .of(id)
+                        .loadMany();
+                }
                 Object.defineProperty(entity, AUDIT_BEFORE_SNAPSHOT, {
                     configurable: true,
                     enumerable: false,

--- a/src/subscribers/audit.subscriber.ts
+++ b/src/subscribers/audit.subscriber.ts
@@ -98,18 +98,25 @@ export class AuditSubscriber implements EntitySubscriberInterface {
             return null;
         }
 
-        const relations: Record<string, boolean> = {};
-
-        auditRelationFields.forEach(field => {
-            relations[field.name] = true;
-        });
-
         const relationBefore = event.entity?.[AUDIT_BEFORE_SNAPSHOT] ?? null;
 
-        const relationAfter = await event.queryRunner.manager.getRepository(event.metadata.target as any).findOne({
+        // Same fix as CRUDService.prepareManyToManyAuditSnapshot: load each audit-tracked
+        // relation independently instead of joining them all into one query, so the row
+        // count of one relation doesn't multiply against every other joined relation.
+        const targetRepo = event.queryRunner.manager.getRepository(event.metadata.target as any);
+        const relationAfter = await targetRepo.findOne({
             where: { id: entityId } as any,
-            relations: relations as any,
         });
+
+        if (relationAfter) {
+            for (const field of auditRelationFields) {
+                (relationAfter as any)[field.name] = await event.queryRunner.manager
+                    .createQueryBuilder()
+                    .relation(event.metadata.target as any, field.name)
+                    .of(entityId)
+                    .loadMany();
+            }
+        }
 
         if (relationBefore && relationAfter) {
             auditRelationFields.forEach(field => {


### PR DESCRIPTION
Summary Updating an entity that has several many-to-many relations flagged with enableAuditTracking: true can time out (canceling statement due to statement timeout) instead of completing, once each relation has more than a small handful of related rows. Confirmed in production on PUT /api/country/:id (Country has 7 audit-tracked many-to-many relations: product, section, pageSeoMetadara, seo, Blogs, falconBanner, testimonial).

Root cause CRUDService.prepareManyToManyAuditSnapshot() (crud.service.ts) and AuditSubscriber.prepareManyToManyAuditUpdateSnapshot() (audit.subscriber.ts) each build the audit before/after snapshot with a single repo.findOne({ relations: {...} }) call that includes every audit-tracked relation at once. TypeORM compiles that into one SQL query with a LEFT JOIN per relation. Joining N sibling many-to-many relations off the same row in a single query produces the cartesian product of their row counts, not the sum — e.g. 7 relations at ~150 rows each yields up to 150⁷ (~1.7 × 10¹⁵) result rows for a single query, which blows past any reasonable statement timeout even though no individual relation holds "a lot" of data.